### PR TITLE
Move croact from devDependencies to dependencies in croact-css-styled

### DIFF
--- a/packages/croact-css-styled/package.json
+++ b/packages/croact-css-styled/package.json
@@ -38,13 +38,13 @@
     "license": "MIT",
     "dependencies": {
         "@daybrush/utils": "^1.13.0",
+        "croact": "^1.0.3",
         "css-styled": "~1.0.8",
         "framework-utils": "^1.1.0"
     },
     "devDependencies": {
         "@daybrush/builder": "^0.1.2",
         "@types/react": "^16.0.0",
-        "croact": "^1.0.3",
         "print-sizes": "^0.2.0",
         "react-css-styled": "~1.1.9",
         "rollup": "^1.29.0",


### PR DESCRIPTION
`croact` is used in an import statement in `styled.d.ts` file in the `croact-css-styled` package, but it is included as `devDependencies` instead of `dependencies`. This causes `vite build` and `vite dev` failures when the package is used in a pnpm monorepo. See detailed explanation in another related pr: https://github.com/daybrush/moveable/pull/1115

Fixing the issue by moving `croact` from `devDependencies` to `dependencies` in the `croact-css-styled` package.